### PR TITLE
Update Android build to Java 21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ Podfile.lock
 gradlew
 gradlew.bat
 .build/
+flutter-sdk/
 **/.cxx/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.3
+
+* Update Android build to Java 21.
+
 ## 0.2.2
 
 * Run setCategory in a thread on iOS to avoid jank (@MinseokKang003).

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,12 +38,12 @@ android {
     compileSdk = 35
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
 
     kotlinOptions {
-        jvmTarget = '11'
+        jvmTarget = '21'
     }
 
     defaultConfig {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -10,12 +10,12 @@ android {
     compileSdk = flutter.compileSdkVersion
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11
+        jvmTarget = JavaVersion.VERSION_21
     }
 
     lint {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: audio_session
 description: Sets the iOS audio session category and Android audio attributes for your app, and manages your app's audio focus, mixing and ducking behaviour.
-version: 0.2.2
+version: 0.2.3
 homepage: https://github.com/ryanheise/audio_session
 topics:
   - audio


### PR DESCRIPTION
## Summary
- update Android and example builds to Java 21
- bump plugin version to 0.2.3
- add entry to CHANGELOG
- ignore local flutter-sdk directory

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6864b80de79c8321b55df1935bedb6f1